### PR TITLE
foosball: add foosball demonstration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Bruno Dilly <bruno.dilly@intel.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(soletta-demos)
+
+include(CheckCXXCompilerFlag)
+include(CheckCCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG("-Wall" CXX_COMPILER_HAS_WALL)
+CHECK_CXX_COMPILER_FLAG("-Wextra" CXX_COMPILER_WALL_HAS_WEXTRA)
+CHECK_CXX_COMPILER_FLAG("-fvisibility=hidden" CXX_COMPILER_HAS_FVISIBILITY)
+
+CHECK_C_COMPILER_FLAG("-std=gnu99" C_COMPILER_HAS_C99)
+CHECK_C_COMPILER_FLAG("-Wall" C_COMPILER_HAS_WALL)
+CHECK_C_COMPILER_FLAG("-Wextra" C_COMPILER_HAS_WEXTRA)
+CHECK_C_COMPILER_FLAG("-Wno-unused-parameter" C_COMPILER_HAS_WNO_UNUSED_PARAMETER)
+CHECK_C_COMPILER_FLAG("-Wno-missing-field-initializers" C_COMPILER_HAS_WNO_MISSING_FIELD_INITIALIZERS)
+CHECK_C_COMPILER_FLAG("-fvisibility=hidden" C_COMPILER_HAS_FVISIBILITY)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
+
+if (CXX_COMPILER_HAS_WALL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif()
+
+if (CXX_COMPILER_WALL_HAS_WEXTRA)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+endif()
+
+if (CXX_COMPILER_HAS_FVISIBILITY)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+endif()
+
+if (C_COMPILER_HAS_FVISIBILITY)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+endif()
+
+if (C_COMPILER_HAS_WEXTRA)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+endif()
+
+if (C_COMPILER_HAS_WALL)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+endif()
+
+if (C_COMPILER_HAS_C99)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+else()
+  message(FATAL_ERROR "No gnu99 support. Bye.")
+endif()
+
+if (C_COMPILER_HAS_WNO_UNUSED_PARAMETER)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter")
+endif()
+
+if (C_COMPILER_HAS_WNO_MISSING_FIELD_INITIALIZERS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers")
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SOLETTA REQUIRED soletta)
+
+add_subdirectory(foosball)

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,29 @@
+This file is part of the Soletta Project
+
+Copyright (C) 2015 Intel Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Intel Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Soletta Demos
+
+Repository of samples for Soletta Project
+
+## Building
+
+Some samples depend on custom node types, so it's required to build
+and install them in a path that can be found by sol-fbp-runner
+
+To do so, execute the following commands in a terminal:
+
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ make install
+
+## Foosball
+
+This demo is composed by two parts: foosball table, where goals are detected
+and provides a small interface with players, and a score counter.
+
+These parts talk to each other using OIC protocol.
+
+So, to properly work, both foosball/table/main.fbp and
+foosball/scoreboard/main.fbp must be running.
+
+### Testing Foosball on development machine
+
+In order to test it in a development machine, open two terminals to
+simulate a table and a scoreboard.
+
+On table terminal run:
+
+    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=foosball/table/conf-gtk.json
+    $ sol-fbp-runner foosball/table/main.fbp
+
+On scoreboad terminal run:
+
+    $ export SOL_MACHINE_ID="666a3d6a9d194a23b90a24573558d2f4"
+    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=foosball/table/conf-gtk.json
+    $ sol-fbp-runner foosball/scoreboard/main.fbp

--- a/foosball/CMakeLists.txt
+++ b/foosball/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(soletta-demos)
+
+add_definitions(-DSOL_FLOW_NODE_TYPE_MODULE_EXTERNAL)
+
+set(NODE_TYPES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/node_types)
+set(SCORE_COUNTER_RESOURCE ${NODE_TYPES_DIR}/oic.r.score.json)
+set(MODULES_DIR ${CMAKE_BINARY_DIR}/module_descriptions)
+set(STAGE_DIR ${CMAKE_BINARY_DIR}/stage)
+set(SCORE_COUNTER_GEN_H ${STAGE_DIR}/score-counter-gen.h)
+set(SCORE_COUNTER_GEN_C ${STAGE_DIR}/score-counter-gen.c)
+set(SCORE_COUNTER_JSON ${STAGE_DIR}/score-counter.json)
+set(SCORE_COUNTER_C ${STAGE_DIR}/score-counter.c)
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=modulesdir soletta
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE SOLETTA_LIB_PREFIX
+  )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=nodeschemapath soletta
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE SCHEMA_PATH
+  )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir soletta
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE SOLETTA_DATA_DIR
+  )
+
+add_custom_command(OUTPUT ${SCORE_COUNTER_C}
+#FIXME use add_custom_command otherwise it always will build this gen files
+#add_custom_command(
+# OUTPUT ${SCORE_COUNTER_GEN_H} ${SCORE_COUNTER_GEN_C}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${STAGE_DIR}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULES_DIR}
+  COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-oic-gen.py --schema-dir=${CMAKE_CURRENT_SOURCE_DIR}/node_types --node-type-json=${SCORE_COUNTER_JSON}  --node-type-impl=${SCORE_COUNTER_C} --node-type-gen-c=${SCORE_COUNTER_GEN_C} --node-type-gen-h=${SCORE_COUNTER_GEN_H}
+  COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-validate.py ${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${SCORE_COUNTER_JSON}
+  COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-gen.py --prefix=sol-flow-node-type --genspec-schema=${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${SCORE_COUNTER_JSON} ${SCORE_COUNTER_GEN_H} ${SCORE_COUNTER_GEN_C} ${MODULES_DIR}/score_counter.json
+  DEPENDS ${SCORE_COUNTER_RESOURCE}
+  )
+
+set(BUILT_SOURCES
+  ${SCORE_COUNTER_GEN_H}
+  ${SCORE_COUNTER_GEN_C}
+  ${SCORE_COUNTER_C}
+  )
+SET_SOURCE_FILES_PROPERTIES(${BUILT_SOURCES} PROPERTIES
+  GENERATED true
+  )
+
+include_directories(
+  ${SOLETTA_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/node_types/
+  )
+
+link_directories(
+  ${SOLETTA_LIBRARY_DIRS}
+  )
+
+add_library(score-counter SHARED
+  ${SCORE_COUNTER_C}
+  )
+set_target_properties(score-counter
+  PROPERTIES PREFIX ""
+  )
+
+target_link_libraries(score-counter
+  ${SOLETTA_LIBRARIES}
+  m)
+
+install(TARGETS score-counter
+  LIBRARY DESTINATION ${SOLETTA_LIB_PREFIX}/flow/
+  )
+
+install(FILES ${CMAKE_BINARY_DIR}/module_descriptions/score_counter.json
+    DESTINATION ${SOLETTA_DATA_DIR}/flow/descriptions
+)

--- a/foosball/node_types/oic.r.score.json
+++ b/foosball/node_types/oic.r.score.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Score Counter",
+  "definitions": {
+    "oic.r.score_counter": {
+      "type": "object",
+      "properties": {
+        "p1_score": {
+          "type": "integer",
+          "description": "Current score of player 1"
+        },
+        "p1_win": {
+          "type": "boolean",
+          "description": "True if player 1 won the match, False if she lost it or match isn't over."
+        },
+        "p2_score": {
+          "type": "integer",
+          "description": "Current score of player 2"
+        },
+        "p2_win": {
+          "type": "boolean",
+          "description": "True if player 2 won the match, False if she lost it or match isn't over."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [ "p1_score", "p2_score", "p1_win", "p2_win" ]
+}

--- a/foosball/scoreboard/main.fbp
+++ b/foosball/scoreboard/main.fbp
@@ -1,0 +1,41 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is the main flow used in the scoreboard.
+# It receives information from table via OIC and update leds to display
+# the score.
+
+ScoreBoard(score-counter/server-score-counter)
+
+ScoreBoard OUT_P1_SCORE -> IN Red(console)
+ScoreBoard OUT_P2_SCORE -> IN Yellow(console)
+ScoreBoard OUT_P1_WIN -> IN RedVictory(console)
+ScoreBoard OUT_P2_WIN -> IN YellowVictory(console)

--- a/foosball/table/README.md
+++ b/foosball/table/README.md
@@ -1,0 +1,20 @@
+== Table ==
+
+When testing it in a development machine, just use gtk conffiles.
+
+    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=foosball/table/conf-gtk.json
+    $ sol-fbp-runner foosball/table/main.fbp
+
+And a GUI should be displayed with controls.
+
+When using Edison conf-edison.json must be used. To match this configuration,
+sensors / actuators must be set on following physical pins:
+
+    * DetectorLightSensor -> Analogic 0
+    * DetectorLed -> Digital 0
+    * MaxLed5 -> Digital 2
+    * MaxLed10 -> Digital 3
+    * MaxButton -> Digital 4
+    * MainResetButton -> Digital 5
+
+== Scoreboard ==

--- a/foosball/table/conf-edison.json
+++ b/foosball/table/conf-edison.json
@@ -1,0 +1,49 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "DetectorLightSensor",
+   "options": {
+    "device": 1,
+    "pin": 0,
+    "poll_timeout": 50
+   },
+   "type": "aio/reader"
+  },
+  {
+   "name": "DetectorLed",
+   "options": {
+    "pin": 130
+   },
+   "type": "gpio/writer"
+  },
+  {
+   "name": "MaxLed5",
+   "options": {
+    "pin": 128
+   },
+   "type": "gpio/writer"
+  },
+  {
+   "name": "MaxLed10",
+   "options": {
+    "pin": 12
+   },
+   "type": "gpio/writer"
+  },
+  {
+   "name": "MaxButton",
+   "options": {
+    "pin": 129
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "MainResetButton",
+   "options": {
+    "pin": 13
+   },
+   "type": "gpio/reader"
+  }
+ ]
+}

--- a/foosball/table/conf-gtk.json
+++ b/foosball/table/conf-gtk.json
@@ -1,0 +1,49 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "DetectorLightSensor",
+   "options": {
+    "range": {
+     "max": 4096
+    }
+   },
+   "type": "gtk/slider"
+  },
+  {
+   "name": "DetectorLed",
+   "options": {
+    "rgb": {
+     "red": 255
+    }
+   },
+   "type": "gtk/led"
+  },
+  {
+   "name": "MaxLed5",
+   "options": {
+    "rgb": {
+     "red": 255
+    }
+   },
+   "type": "gtk/led"
+  },
+  {
+   "name": "MaxLed10",
+   "options": {
+    "rgb": {
+     "green": 255
+    }
+   },
+   "type": "gtk/led"
+  },
+  {
+   "name": "MaxButton",
+   "type": "gtk/toggle"
+  },
+  {
+   "name": "MainResetButton",
+   "type": "gtk/pushbutton"
+  }
+ ]
+}

--- a/foosball/table/goal-detector.fbp
+++ b/foosball/table/goal-detector.fbp
@@ -1,0 +1,69 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a subflow used to read variations on an enlightened light sensor.
+# Everytime a ball pass between the led and light sensor variations will
+# be detected and a pulse will be sent through an exported port.
+#
+# Using one on each side of the foosball table make it possible to identify
+# when goals happen.
+#
+# Exported output ports:
+#  * GOAL (pulse)
+
+OUTPORT=Goal.OUT:GOAL
+
+# Turn led on
+Led(DetectorLed)
+True(constant/boolean:value=true)
+True OUT -> IN Led
+
+# Send pulse when measured light is below 70% of env light
+# It indicates a ball has passed in front the led
+ValuesBuffer(int/buffer:circular=true, samples=10, operation="mean", timeout=1)
+Threshold(float/multiplication)
+Rate(constant/float:value=0.7)
+BelowThreshold(int/less)
+
+# Filter is required to avoid multiple consecutive readings of light
+# below threshold to be interpreted as multiple goals.
+Filter(filter-repeated/boolean)
+Goal(converter/boolean-to-empty)
+
+Sensor(DetectorLightSensor)
+
+Sensor OUT -> IN ValuesBuffer
+ValuesBuffer OUT -> IN _(converter/int-to-float) OUT -> OPERAND[0] Threshold
+Rate OUT -> OPERAND[1] Threshold
+
+Sensor OUT -> IN[0] BelowThreshold
+Threshold OUT -> IN _(converter/float-to-int) OUT -> IN[1] BelowThreshold
+BelowThreshold OUT -> IN Filter OUT -> PULSE_IF_TRUE Goal

--- a/foosball/table/goals-max.fbp
+++ b/foosball/table/goals-max.fbp
@@ -1,0 +1,53 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a subflow used for selection of maximum goals per match.
+# User can select between 5 or 10 goals per match with a button and
+# 2 leds represent which option is on use.
+#
+# Exported output ports:
+#  * MAX (int)
+
+OUTPORT=Max.OUT:MAX
+
+InitialState(constant/boolean:value=false)
+Hub(switcher/boolean)
+Led5(MaxLed5)
+Led10(MaxLed10)
+Button(MaxButton)
+Max(converter/boolean-to-int:false_value=5, true_value=10)
+
+InitialState OUT -> IN[0] Hub
+Button OUT -> IN[0] Hub
+
+Hub OUT[0] -> IN Max
+Hub OUT[0] -> IN Led10
+Hub OUT[0] -> IN _(boolean/not) OUT -> IN Led5

--- a/foosball/table/main.fbp
+++ b/foosball/table/main.fbp
@@ -1,0 +1,77 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is the main flow used in the table of foosball.
+# It controls goals per match, reset scores, and communicates with
+# scoreboard via OIC. When a team wins it waits for 5 seconds before
+# starting next match.
+
+DECLARE=ScoreCounter:fbp:score-counter.fbp
+DECLARE=GoalsMax:fbp:goals-max.fbp
+
+RedScore(ScoreCounter)
+YellowScore(ScoreCounter)
+Max(GoalsMax)
+
+ResetButton(MainResetButton)
+
+ScoreBoard(score-counter/client-score-counter:device_id="666a3d6a9d194a23b90a24573558d2f4")
+Reset(converter/boolean-to-empty)
+ResetWon(boolean/filter)
+ResetTimer(timer:interval=5000)
+TimerState(converter/empty-to-boolean:output_value=false)
+Disable(constant/boolean:value=false)
+
+RedWon(int/equal)
+YellowWon(int/equal)
+
+ResetButton OUT -> PULSE_IF_TRUE Reset
+Reset OUT -> RESET RedScore
+Reset OUT -> RESET YellowScore
+
+RedScore SCORE -> IN[0] RedWon
+Max MAX -> IN[1] RedWon
+RedWon OUT -> IN ResetWon
+
+YellowScore SCORE -> IN[0] YellowWon
+Max MAX -> IN[1] YellowWon
+YellowWon OUT -> IN ResetWon
+
+Disable OUT -> ENABLED ResetTimer
+ResetWon TRUE -> ENABLED ResetTimer
+ResetTimer OUT -> IN TimerState
+TimerState OUT -> ENABLED ResetTimer
+TimerState OUT -> PULSE_IF_FALSE Reset
+
+RedScore SCORE -> IN_P1_SCORE ScoreBoard
+YellowScore SCORE -> IN_P2_SCORE ScoreBoard
+RedWon OUT -> IN_P1_WIN ScoreBoard
+YellowWon OUT -> IN_P2_WIN ScoreBoard

--- a/foosball/table/score-counter.fbp
+++ b/foosball/table/score-counter.fbp
@@ -1,0 +1,49 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a subflow used to keep score of a team.
+# It increments a counter when goals are detected and reset when
+# a team win or user reset counting (via table control).
+#
+# Exported input ports:
+#  * RESET (pulse)
+# Exported output ports:
+#  * SCORE (int)
+
+OUTPORT=Score.OUT:SCORE
+INPORT=Score.RESET:RESET
+
+DECLARE=GoalDetector:fbp:goal-detector.fbp
+
+Score(int/accumulator)
+Goal(GoalDetector)
+
+Goal GOAL -> INC Score


### PR DESCRIPTION
This demo is composed by two parts: foosball table, where goals are
detected and provides a small interface with players, and a score counter.

These parts talk to each other using OIC protocol.

TODO:
    \* scoreboard implementation - gtk and edison confs
    \* handle goal-detector configurations on table (it only works for gtk)

For now it's possible to test it in a dev machine simulating the table
in a side and values will be printed in console by scoreboard process.

Signed-off-by: Bruno Dilly bruno.dilly@intel.com
