### PR TITLE
factory-monitor: Add new 'factory-monitor' demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,3 +60,4 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(SOLETTA REQUIRED soletta)
 
 add_subdirectory(foosball)
+add_subdirectory(factory-monitor)

--- a/factory-monitor/CMakeLists.txt
+++ b/factory-monitor/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(soletta-demos)
+
+add_definitions(-DSOL_FLOW_NODE_TYPE_MODULE_EXTERNAL)
+
+set(NODE_TYPES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/node_types)
+set(MONITOR_RESOURCE ${NODE_TYPES_DIR}/oic.r.monitor.json)
+set(MODULES_DIR ${CMAKE_BINARY_DIR}/module_descriptions)
+set(STAGE_DIR ${CMAKE_BINARY_DIR}/stage)
+set(STAGE_DIR ${CMAKE_BINARY_DIR}/stage)
+set(MONITOR_GEN_H ${STAGE_DIR}/monitor-gen.h)
+set(MONITOR_GEN_C ${STAGE_DIR}/monitor-gen.c)
+set(MONITOR_JSON ${STAGE_DIR}/monitor.json)
+set(MONITOR_C ${STAGE_DIR}/monitor.c)
+set(MONITOR_GEN_JSON ${MODULES_DIR}/monitor.json)
+set(CUSTOM_NODE_JSON ${NODE_TYPES_DIR}/custom-node.json)
+set(CUSTOM_NODE_C ${NODE_TYPES_DIR}/custom-node.c)
+set(CUSTOM_NODE_GEN_H ${STAGE_DIR}/custom-node-gen.h)
+set(CUSTOM_NODE_GEN_C ${STAGE_DIR}/custom-node-gen.c)
+set(CUSTOM_NODE_GEN_JSON ${STAGE_DIR}/custom-node-gen.json)
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=modulesdir soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SOLETTA_LIB_PREFIX
+    )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=nodeschemapath soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SCHEMA_PATH
+    )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SOLETTA_DATA_DIR
+    )
+
+add_custom_command(OUTPUT ${MONITOR_C} ${MONITOR_GEN_C} ${MONITOR_GEN_H} ${MONITOR_JSON}
+    DEPENDS ${MONITOR_RESOURCE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${STAGE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULES_DIR}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-oic-gen.py --schema-dir=${NODE_TYPES_DIR} --node-type-json=${MONITOR_JSON} --node-type-impl=${MONITOR_C} --node-type-gen-c=${MONITOR_GEN_C} --node-type-gen-h=${MONITOR_GEN_H}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-validate.py ${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${MONITOR_JSON}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-gen.py --prefix=sol-flow-node-type --genspec-schema=${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${MONITOR_JSON} ${MONITOR_GEN_H} ${MONITOR_GEN_C} ${MONITOR_GEN_JSON}
+    )
+
+add_custom_target(custom-node-gen
+    BYPRODUCTS ${CUSTOM_NODE_GEN_C} ${CUSTOM_NODE_GEN_H} ${CUSTOM_NODE_GEN_JSON}
+    DEPENDS ${CUSTOM_NODE_JSON} ${CUSTOM_NODE_C} ${MONITOR_GEN_H}
+    COMMAND echo "Generating custom node code..."
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${STAGE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULES_DIR}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-validate.py ${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${CUSTOM_NODE_JSON}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-gen.py --prefix=sol-flow-node-type --genspec-schema=${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${CUSTOM_NODE_JSON} ${CUSTOM_NODE_GEN_H} ${CUSTOM_NODE_GEN_C} ${CUSTOM_NODE_GEN_JSON}
+    COMMAND echo "Done."
+    )
+
+set(BUILT_SOURCES
+    ${MONITOR_GEN_H}
+    ${MONITOR_GEN_C}
+    ${MONITOR_C}
+    ${CUSTOM_NODE_GEN_H}
+    ${CUSTOM_NODE_GEN_C}
+    )
+SET_SOURCE_FILES_PROPERTIES(${BUILT_SOURCES} PROPERTIES
+    GENERATED true
+    )
+
+include_directories(
+    ${SOLETTA_INCLUDE_DIRS}
+    ${STAGE_DIR} #Check if ok
+    )
+
+link_directories(
+    ${SOLETTA_LIBRARY_DIRS}
+    )
+
+add_library(monitor SHARED
+    ${MONITOR_C}
+    )
+set_target_properties(monitor
+    PROPERTIES PREFIX ""
+    )
+target_link_libraries(monitor
+    ${SOLETTA_LIBRARIES}
+    )
+
+add_library(custom-node SHARED
+    ${CUSTOM_NODE_C}
+    )
+add_dependencies(custom-node
+    custom-node-gen
+    )
+set_target_properties(custom-node
+    PROPERTIES PREFIX ""
+    )
+target_link_libraries(custom-node
+    ${SOLETTA_LIBRARIES}
+    )
+
+install(TARGETS monitor custom-node
+    LIBRARY DESTINATION ${SOLETTA_LIB_PREFIX}/flow/
+    )
+
+install(FILES ${MONITOR_GEN_JSON} ${CUSTOM_NODE_GEN_JSON}
+    DESTINATION ${SOLETTA_DATA_DIR}/flow/descriptions
+    )

--- a/factory-monitor/fbp/main.fbp
+++ b/factory-monitor/fbp/main.fbp
@@ -1,0 +1,148 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2016 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is the main flow of the factory-monitor.
+# It has an OIC server - more details about it on server fbp, currently
+# only 'server-dummy.fbp'.
+# Its OIC client custom-node observers a list of servers, showing
+# temperature readings of them in a rouding roibin fashion. When
+# one of the servers outputs 'FAILURE' alert, client shows corresponding
+# message. Then, one is expected to use Buttons to decide what to do
+# regarding the failure: Dismiss it or report it.
+# To dismiss, one just needs to press btn1. If press btn2, a selector form
+# will be shown to choose a name to report the failure. In the form, btn1
+# chooses a name, and btn2 circle the list of names.
+
+scanner(monitor/client-temperature)
+temperature_pool(custom-node/server-pool)
+timer_scan(timer:interval=5000)
+timer_display(timer:interval=3000)
+
+lcd(Display)
+led(Led)
+#buzzer(Buzzer:tune="ccggaa|111122|300")
+
+raw_btn1(Btn1)
+raw_btn2(Btn2)
+
+btn1(switcher/empty)
+raw_btn1 OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> IN[0] btn1
+
+btn2(switcher/empty)
+raw_btn2 OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> IN[0] btn2
+
+normal_msg(string/concatenate)
+_(constant/string:value="\n") OUT -> IN[1] normal_msg
+_(constant/string:value=" C") OUT -> IN[3] normal_msg
+
+error_msg(string/concatenate)
+_(constant/string:value="Failure on ") OUT -> IN[0] error_msg
+
+supervisor_selector(form/selector:rows=2,columns=16,circular=true)
+supervisors(test/string-generator:sequence="Denethor Saruman Sauron Morgoth --Cancel")
+supervisors OUT -> ADD_ITEM supervisor_selector
+
+msg_switcher(switcher/string:keep_state=true)
+normal_msg OUT -> IN[0] msg_switcher
+error_msg OUT -> IN[1] msg_switcher
+supervisor_selector STRING -> IN[2] msg_switcher
+
+#Start with led OFF and 'Scanning...' message
+_(constant/boolean:value=false) OUT -> IN led
+_(constant/string:value="Scanning...") OUT -> IN lcd
+
+#Continuously scan devices
+timer_scan OUT -> SCAN scanner
+scanner DEVICE_ID -> ADD_DEVICE_ID temperature_pool
+
+#Keep cicling information of known devices
+timer_display OUT -> TICK temperature_pool
+
+#Prepare normal information
+temperature_pool OUT_NAME -> IN[0] normal_msg
+temperature_pool OUT_TEMPERATURE -> IN _(converter/float-to-string) OUT -> IN[2] normal_msg
+
+#Prepare error information
+temperature_pool OUT_NAME -> IN[1] error_msg
+
+#Decides if shows a normal message or an error one
+temperature_pool OUT_FAILURE -> IN failure(boolean/filter)
+failure TRUE -> IN error_screen(converter/empty-to-int:output_value=1) OUT -> IN_PORT msg_switcher
+failure FALSE -> IN normal_screen(converter/empty-to-int:output_value=0) OUT -> IN_PORT msg_switcher
+msg_switcher OUT[0] -> IN lcd
+
+#Turn Led on on failure, stops timer_display and start buzzer
+#If not on failure, do the opposite.
+temperature_pool OUT_FAILURE -> IN led
+temperature_pool OUT_FAILURE -> IN _(boolean/not) OUT -> ENABLED timer_display
+#temperature_pool OUT_FAILURE -> ENABLED buzzer
+
+#Buttons have three states: 0 - Disabled, 1 - On error screen, 2 - On selector screen
+#On failure, enable state 1
+failure TRUE -> IN btn_state1(converter/empty-to-int:output_value=1)
+btn_state1 OUT -> OUT_PORT btn1
+btn_state1 OUT -> OUT_PORT btn2
+
+#If choose 'To report supervisors', enable state 2
+btn2 OUT[1] -> IN btn_state2(converter/empty-to-int:output_value=2)
+btn_state2 OUT -> OUT_PORT btn1
+btn_state2 OUT -> OUT_PORT btn2
+
+#Btn1 act as 'dismiss' on state 1
+btn1 OUT[1] -> IN dismiss(converter/empty-to-boolean:output_value=true)
+dismiss OUT -> IN _(boolean/not) OUT -> SET_FAILURE temperature_pool
+dismiss OUT -> ENABLED timer_display
+dismiss OUT -> IN _(converter/empty-to-string:output_value="Dismissed") OUT -> IN lcd
+dismiss OUT -> IN btn_state0(converter/empty-to-int:output_value=0)
+btn_state0 OUT -> OUT_PORT btn1
+btn_state0 OUT -> OUT_PORT btn2
+
+#Btn2 activated, show a list of 'supervisors'
+btn2 OUT[1] -> IN supervisors_screen(converter/empty-to-int:output_value=2) OUT -> IN_PORT msg_switcher
+
+#Buttons now control form/selector
+btn1 OUT[2] -> SELECT supervisor_selector
+btn2 OUT[2] -> NEXT supervisor_selector
+
+#If '--Cancel' was the chosen item, go back to state 2 (error screen)
+supervisor_selector SELECTED -> IN str_sw(string/starts-with:prefix="--")
+str_sw OUT -> IN canceled(boolean/filter)
+canceled TRUE -> IN btn_state1
+canceled TRUE -> IN error_screen
+
+#If a name was chosen, dismiss error msg
+canceled FALSE -> IN dismiss
+
+#Server nodes
+#TODO enable other servers than dummy, that run on different devices.
+DECLARE=Server:fbp:server-dummy.fbp
+
+server(Server)

--- a/factory-monitor/fbp/server-dummy.fbp
+++ b/factory-monitor/fbp/server-dummy.fbp
@@ -1,0 +1,44 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2016 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is a dummy server - it does not read a temperature sensor,
+# instead, uses a timer and an accumulator to output dummy temperature values.
+# It also sets FAILURE state each 15 seconds. Useful for testing on desktop.
+
+server_temperature(oic/server-temperature)
+server_name(constant/string:value="Thermometer") OUT -> IN_NAME server_temperature
+
+server_timer(timer:interval=10000) OUT -> INC server_accumulator(int/accumulator)
+server_accumulator OUT -> IN _(converter/int-to-float) OUT -> IN_TEMPERATURE server_temperature
+server_temperature OUT_TEMPERATURE -> IN _(console)
+
+server_timer_failure(timer:interval=15000)
+server_timer_failure OUT -> IN _(boolean/toggle) OUT -> IN_FAILURE server_temperature

--- a/factory-monitor/fbp/sol-flow.json
+++ b/factory-monitor/fbp/sol-flow.json
@@ -1,0 +1,24 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "Display",
+   "type": "gtk/label"
+  },
+  {
+   "name": "Led",
+   "options": {
+    "rgb": "0|255|0"
+   },
+   "type": "gtk/led"
+  },
+  {
+   "name": "Btn1",
+   "type": "gtk/pushbutton"
+  },
+  {
+   "name": "Btn2",
+   "type": "gtk/pushbutton"
+  }
+ ]
+}

--- a/factory-monitor/node_types/custom-node.c
+++ b/factory-monitor/node_types/custom-node.c
@@ -1,0 +1,356 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "custom-node-gen.h"
+#include "monitor-gen.h"
+#include "sol-flow-static.h"
+
+#include <sol-mainloop.h>
+#include <errno.h>
+
+struct resource_data {
+    char *device_id;
+    char *name;
+    double temperature;
+    bool failure;
+    union {
+        struct {
+            uint8_t temperature_ready : 1;
+            uint8_t name_ready : 1;
+            uint8_t failure_ready : 1;
+        };
+        uint8_t ready;
+    };
+};
+
+struct internal_data {
+    struct sol_vector resources;
+    struct sol_timeout *timeout;
+    struct sol_flow_node *node;
+    uint16_t current_idx;
+    uint16_t fetch_idx;
+};
+
+static int
+next_idx(int idx, int max_idx)
+{
+    if (++idx >= max_idx)
+        idx = 0;
+
+    return idx;
+}
+
+static bool
+timeout_cb(void *data)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+
+    if (mdata->resources.len == 0) {
+        SOL_DBG("No resources available yet");
+        return true;
+    }
+
+    mdata->fetch_idx = next_idx(mdata->fetch_idx, mdata->resources.len);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, true);
+
+    sol_flow_send_string_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_DEVICE_ID,
+        resource->device_id);
+
+    return true;
+}
+
+static int
+internal_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct internal_data *mdata = data;
+
+    sol_vector_init(&mdata->resources, sizeof(struct resource_data));
+
+    mdata->timeout = sol_timeout_add(900, timeout_cb, mdata);
+    SOL_NULL_CHECK(mdata->timeout, -ENOMEM);
+
+    mdata->node = node;
+
+    return 0;
+}
+
+static void
+internal_close(struct sol_flow_node *node, void *data)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    uint16_t i;
+
+    SOL_VECTOR_FOREACH_IDX (&mdata->resources, resource, i) {
+        free(resource->name);
+        free(resource->device_id);
+    }
+    sol_vector_clear(&mdata->resources);
+
+    sol_timeout_del(mdata->timeout);
+}
+
+static int
+internal_process_failure(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    bool in_value;
+    int r;
+
+    r = sol_flow_packet_get_boolean(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOMEM);
+
+    resource->failure = in_value;
+    resource->failure_ready = true;
+
+    return 0;
+}
+
+static int
+internal_process_name(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    const char *in_value;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    if (!resource->name || strcmp(resource->name, in_value)) {
+        free(resource->name);
+        resource->name = strdup(in_value);
+        resource->name_ready = true;
+    }
+
+    return 0;
+}
+
+static int
+internal_process_temperature(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    struct sol_drange in_value;
+    int r;
+
+    r = sol_flow_packet_get_drange(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    resource->temperature = in_value.val;
+    resource->name_ready = true;
+
+    return 0;
+}
+
+static int
+process_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    uint16_t last_idx;
+
+    if (mdata->resources.len == 0) {
+        SOL_WRN("No resource available");
+        return 0;
+    }
+
+    last_idx = mdata->current_idx;
+
+    resource = sol_vector_get(&mdata->resources, mdata->current_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    /* Let's try to find a ready resource, i.e., one whose data is known
+     * If we fail, give up*/
+    while (!resource->ready) {
+        mdata->current_idx = next_idx(mdata->current_idx, mdata->resources.len);
+        if (mdata->current_idx == last_idx) {
+            SOL_DBG("No ready resource");
+            return 0; /* No ready resource*/
+        }
+
+        resource = sol_vector_get(&mdata->resources, mdata->current_idx);
+        SOL_NULL_CHECK(resource, -ENOENT);
+    }
+
+    sol_flow_send_string_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__DEVICE_ID, resource->device_id);
+    sol_flow_send_string_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_NAME, resource->name);
+    sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_FAILURE, resource->failure);
+    sol_flow_send_drange_value_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_TEMPERATURE,
+        resource->temperature);
+
+    mdata->current_idx = next_idx(mdata->current_idx, mdata->resources.len);
+
+    return 0;
+}
+
+static int
+process_failure(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    bool in_value;
+
+    r = sol_flow_packet_get_boolean(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_FAILURE, in_value);
+
+    return 0;
+}
+
+static int
+add_device_id_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    const char *in_value;
+    struct resource_data *resource;
+    uint16_t i;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    SOL_VECTOR_FOREACH_IDX (&mdata->resources, resource, i) {
+        if (!strcmp(resource->device_id, in_value)) {
+            SOL_DBG("Ignoring known resource %s", in_value);
+            return 0;
+        }
+    }
+
+    resource = sol_vector_append(&mdata->resources);
+    SOL_NULL_CHECK(resource, -ENOMEM);
+
+    resource->device_id = strdup(in_value);
+    SOL_NULL_CHECK_GOTO(resource->device_id, err);
+
+    return 0;
+
+err:
+    sol_vector_del_last(&mdata->resources);
+    return -ENOMEM;
+}
+
+static void
+custom_pool_new_type(const struct sol_flow_node_type **current)
+{
+    struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *oic_client;
+
+    static struct sol_flow_static_node_spec nodes[] = {
+        { NULL, "custom-controller", NULL },
+        { NULL, "monitor-client-temperature", NULL },
+        SOL_FLOW_STATIC_NODE_SPEC_GUARD
+    };
+
+    /**
+     * Remember: SET_FAILURE port will send a message to server about failure;
+     *           OUT_FAILURE port will send locally current status, like
+     *           OUT_TEMPERATURE.
+     */
+    static const struct sol_flow_static_conn_spec conns[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_DEVICE_ID, 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__IN__DEVICE_ID },
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_FAILURE, 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__IN__IN_FAILURE },
+
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_FAILURE, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_FAILURE },
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_TEMPERATURE, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_TEMPERATURE },
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_NAME, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_NAME },
+
+        SOL_FLOW_STATIC_CONN_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_port_spec exported_out[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__DEVICE_ID},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_TEMPERATURE},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_NAME},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_FAILURE},
+        SOL_FLOW_STATIC_PORT_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_port_spec exported_in[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__SET_FAILURE},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__TICK},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__ADD_DEVICE_ID},
+        SOL_FLOW_STATIC_PORT_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_spec spec = {
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
+        .nodes = nodes,
+        .conns = conns,
+        .exported_in = exported_in,
+        .exported_out = exported_out
+    };
+
+    if (sol_flow_get_node_type("monitor", SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE, &oic_client) < 0) {
+        *current = NULL;
+        return;
+    }
+
+    nodes[0].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER;
+    nodes[1].type = oic_client;
+
+    type = sol_flow_static_new_type(&spec);
+    SOL_NULL_CHECK(type);
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    type->description = (*current)->description;
+#endif
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
+    *current = type;
+}
+
+static void
+custom_init_type(void)
+{
+    custom_pool_new_type(&SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL);
+}
+
+#include "custom-node-gen.c"

--- a/factory-monitor/node_types/custom-node.json
+++ b/factory-monitor/node_types/custom-node.json
@@ -1,0 +1,159 @@
+{
+   "$schema": "http://solettaproject.github.io/soletta/schemas/node-type-genspec.schema",
+   "name": "server-pool",
+   "meta": {
+      "author": "Intel Corporation",
+      "license": "BSD-3-Clause",
+      "version": "1"
+   },
+   "types": [
+      {
+         "category": "internal",
+         "description": "Controler for custom node. Shall keep a list of N servers, continuously ask their status, etc",
+         "in_ports": [
+            {
+               "description": "Failure state",
+               "name": "SET_FAILURE",
+               "methods": {
+                  "process": "process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Current sensed Temperature",
+               "name": "IN_TEMPERATURE",
+               "methods": {
+                  "process": "internal_process_temperature"
+               },
+               "data_type": "float"
+            },
+            {
+               "description": "Friendly device name (e.g. Kitchen Temperature)",
+               "name": "IN_NAME",
+               "methods": {
+                  "process": "internal_process_name"
+               },
+               "data_type": "string"
+            },
+            {
+               "description": "Failure state",
+               "name": "IN_FAILURE",
+               "methods": {
+                  "process": "internal_process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Each packet received on this port sends next server information to output ports",
+               "name": "TICK",
+               "methods": {
+                  "process": "process_tick"
+               },
+               "data_type": "any"
+            },
+            {
+               "description": "Add device id to be observed.",
+               "name": "ADD_DEVICE_ID",
+               "methods": {
+                  "process": "add_device_id_process"
+               },
+               "data_type": "string"
+            }
+         ],
+         "methods": {
+            "open": "internal_open",
+            "close": "internal_close"
+         },
+         "name": "custom-node/server-pool-controller",
+         "out_ports": [
+            {
+               "description": "Send DEVICE_ID packet to set client device id",
+               "name": "SET_DEVICE_ID",
+               "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "SET_FAILURE",
+               "data_type": "boolean"
+            },
+            {
+                "description": "Id of current server, from where cames current temperature, etc.",
+                "name": "DEVICE_ID",
+                "data_type": "string"
+            },
+            {
+                "description": "Current sensed Temperature",
+                "name": "OUT_TEMPERATURE",
+                "data_type": "float"
+            },
+            {
+                "description": "Friendly device name (e.g. Kitchen Temperature)",
+                "name": "OUT_NAME",
+                "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "OUT_FAILURE",
+               "data_type": "boolean"
+            }
+         ],
+         "private_data_type": "internal_data"
+      },
+      {
+         "category": "custom",
+         "description": "Custom node. Shall keep a list of N servers, continuously ask their status, etc",
+         "in_ports": [
+            {
+               "description": "Failure state",
+               "name": "SET_FAILURE",
+               "methods": {
+                  "process": "process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Each packet received on this port sends next server information to output ports",
+               "name": "TICK",
+               "methods": {
+                  "process": "process_tick"
+               },
+               "data_type": "any"
+            },
+            {
+               "description": "Add device id to be observed.",
+               "name": "ADD_DEVICE_ID",
+               "methods": {
+                  "process": "add_device_id_process"
+               },
+               "data_type": "string"
+            }
+         ],
+         "methods": {
+            "init_type": "custom_init_type"
+         },
+         "name": "custom-node/server-pool",
+         "out_ports": [
+            {
+                "description": "Send packets with IDs for all servers that respond to scan request. Such IDs can be used to connect to a client to a different server through input port DEVICE_ID",
+                "name": "DEVICE_ID",
+                "data_type": "string"
+            },
+            {
+                "description": "Current sensed Temperature",
+                "name": "OUT_TEMPERATURE",
+                "data_type": "float"
+            },
+            {
+                "description": "Friendly device name (e.g. Kitchen Temperature)",
+                "name": "OUT_NAME",
+                "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "OUT_FAILURE",
+               "data_type": "boolean"
+            }
+         ]
+      }
+   ]
+}

--- a/factory-monitor/node_types/oic.r.monitor.json
+++ b/factory-monitor/node_types/oic.r.monitor.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Test temperature",
+  "definitions": {
+    "core.temperature": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Friendly device name (e.g. Kitchen Temperature)"
+        },
+        "temperature": {
+          "type": "number",
+          "description": "ReadOnly,Current sensed Temperature"
+        },
+        "failure": {
+          "type": "boolean",
+          "description": "Current failure status"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [ "temperature" ]
+}


### PR DESCRIPTION
This demo exemplifies a factory floor monitor: several terminal
that connect, using OIC, to several monitors. Each monitor outputs
current temperature readings and a FAILURE state.
Terminals usually show monitor temperature on a rounding robin fashion.
However, if any monitor sets its FAILURE state to true, terminals will
stop showing temperature and will show the failure status.
When on failure status, one can use available buttons to 1) Dismiss
failure status 2) Report to some 'supervisor' - action that dismiss
failure status as well. After dimiss, terminals go back to showing
monitors temperature.
Right now, one can only see this demo on desktop - with fake
temperatures and failures - but later specific 'sol-flow.json'
configuration files will be given to use on different devices.

Signed-off-by: Ederson de Souza ederson.desouza@intel.com
