### PR TITLE
factory-monitor: Add new 'factory-monitor' demo [v3]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,3 +60,4 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(SOLETTA REQUIRED soletta)
 
 add_subdirectory(foosball)
+add_subdirectory(factory-monitor)

--- a/README.md
+++ b/README.md
@@ -39,3 +39,192 @@ On scoreboad terminal run:
     $ export SOL_MACHINE_ID="666a3d6a9d194a23b90a24573558d2f4"
     $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=foosball/scoreboard/sol-flow.json
     $ sol-fbp-runner foosball/scoreboard/main.fbp
+
+## Factory monitor
+
+This demo exemplifies a factory floor monitor: several terminal
+that connect, using OIC, to several monitors. Each monitor outputs
+current temperature reading and a FAILURE state.
+Terminals usually show monitor temperature on a round robin fashion.
+However, if any monitor sets its FAILURE state to true, terminals
+will stop showing temperature and will show the failure status.
+When on failure state, one cau use available buttons to 1) Dismiss
+failure status 2) Report to some 'supervisor' - action that dismiss
+failure status as well. After dismiss, terminals go back to showing
+monitors temperature.
+
+### Testing on development machine
+
+To simplify testing, this demo provides a sol-flow.json that uses GTK
+widgets as input/output. It also provides a server-dummy.fbp that doesn't
+really reads a temperature sensor, but instead show fake increasing
+values. To use the server-dummy.fbp, search for `##Server nodes` on
+`factory-monitor/fbp/main.fbp` and uncomment the line
+
+    DECLARE=Server:fbp:server-dummy.fbp
+
+Then, run `factory-monitor/fbp/main.fbo`:
+
+    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=factory-monitor/fbp/sol-flow.json
+    $ sol-fbp-runner factory-monitor/fbp/main.fbp
+
+If desired, it's possible to execute only the server - on different
+machines or VMs for instance - to get different instances of server.
+
+    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=factory-monitor/fbp/sol-flow.json
+    $ sol-fbp-runner factory-monitor/fbp/server-dummy.fbp
+
+If doing so, remember to change server_name to another name, so you
+can differentiate them:
+
+```sh
+server_name(constant/string:value="Thermometer alpha")
+```
+
+If you run different servers on the same machine, it's necessary to give
+a different `SOL_MACHINE_ID` to each:
+
+
+    $ SOL_MACHINE_ID=2f3089a1dbfb43d38cab64383bdf9380 sol-fbp-runner factory-monitor/fbp/server-dummy.fbp
+
+**Note:** Running more than one instance of server **will not work** on
+Linux. Client will only bind to one of them. Run different servers on
+different machines or virtual machines to workaround this.
+
+### Testing on quark se development board
+
+Use sol-flow-quark-se-devboard.json configuration file - the simplest way
+is to rename it to `sol-flow.json` - but be careful to not overwrite GTK
+one:
+
+    $ mv factory-monitor/fbp/sol-flow.json factory-monitor/fbp/sol-flow-gtk.json
+    $ mv factory-monitor/fbp/sol-flow-quark-se-devboard.json factory-monitor/fbp/sol-flow.json
+
+Then, search for `##Server nodes` on `factory-monitor/fbp/main.fbp` and
+ensure that only the line
+
+    DECLARE=Server:fbp:server-quark-se-devboard.fbp
+
+is uncommented among the server `DECLARE`s.
+
+### Testing on MinnowBoard MAX using 6LoWPAN with a CC2520 radio on Ostro
+
+It's possible to run this demo using 6LoWPAN on a MinnowBoard MAX with
+Ostro image installed. A CC2520 radio is required.
+
+#### Wiring CC2520 on MinnowBoard MAX
+
+The following connections must be made. For those using a CC2520EMK, it's
+also provided pin numbers to be used.
+
+```
+MinnowBoard MAX pin         CC2520              CC2520EMK pin
+4 (3v3)                     VDD                 P2.7
+2 (GND)                     GND                 P1.19
+5 (SPI_CS)                  SPI_CS              P1.14
+7 (SPI_MISO)                SPI_MISO            P1.20
+9 (SPI_MOSI)                SPI_MOSI            P1.18
+11 (SPI_SCK)                SPI_SCK             P1.16
+21 (GPIO_338)               FIFO                P1.7
+22 (GPIO_504)               SFD                 P2.18
+23 (GPIO_339)               FIFOP               P1.9
+24 (GPIO_505)               RESET               P2.15
+25 (GPIO_340)               CCA                 P1.12
+26 (GPIO_464)               VREG                P1.10
+```
+
+#### Wiring buttons and led on a Calamari Lure
+
+This sample uses three buttons and a led also. One can wire them directly,
+but for simplicity, we used a Calamari lure. Note that we didn't wired
+MinnowBoard MAX pins to their counterparts on Calamari. If wiring buttons
+and led directly on a protoboard, remember to wire them to GPIO of
+MinnowBoard MAX.
+
+```
+MinnowBoard MAX pin         Calamari Pin
+4 (3v3)                     4 (3v3)
+2 (GND)                     2 (GND)
+14 (GPIO_472)               22 (LED1)
+16 (GPIO_473)               14 (BTN1)
+18 (GPIO_475)               10 (BTN2)
+20 (GPIO_474)               12 (BTN3)
+```
+
+Note that you may want to use a breadboard to easy wiring.
+
+#### Setup 6LoWPAN on Ostro
+
+After wiring and booting MinnowBoard MAX with Ostro image, you'll need
+to setup CC2520 radio and 6LoWPAN:
+
+```
+insmod /lib/modules/4.1.15-yocto-standard/extra/spi-minnow-cc2520.ko
+insmod /lib/modules/4.1.15-yocto-standard/extra/spi-minnow-board.ko
+ip link set wpan0 address a0:0:0:0:0:0:0:2
+iz set wpan0 777 8002 11
+ifconfig wpan0 up
+ip link add link wpan0 name lowpan0 type lowpan
+ifconfig lowpan0 up
+```
+
+If setting up two devices, remember to change address on second:
+```
+insmod /lib/modules/4.1.15-yocto-standard/extra/spi-minnow-cc2520.ko
+insmod /lib/modules/4.1.15-yocto-standard/extra/spi-minnow-board.ko
+ip link set wpan0 address a0:0:0:0:0:0:0:3
+iz set wpan0 777 8003 11
+ifconfig wpan0 up
+ip link add link wpan0 name lowpan0 type lowpan
+ifconfig lowpan0 up
+```
+
+If you create a script to do this setup, you may need to wait between
+two commands, so the previous one has completed any system alteration
+it does.
+
+#### Running demo
+
+One can run demo by running
+```
+sol-fbp-runner fbp/main.fbp
+```
+
+Remember to use `server-dummy.fbp`. Soletta shall use
+`sol-flow-intel-minnow-max-linux_gt_3_17.json` configuration file
+autmatically - in case it doesn't, rename it to `sol-flow.json` on
+MinnowBoard MAX.
+
+Calamari Button3 shall set FAILURE state. Buttons 1 & 2 shall control
+demo normal flow.
+
+Note that while showing available 'Temperatures', you may see somethig
+like
+```
+lcd Thermometer B
+6.000000 C (string)
+lcd Thermometer B
+6.000000 C (string)
+lcd Thermometer B
+8.000000 C (string)
+lcd Thermometer A
+8.000000 C (string)
+lcd Thermometer A
+8.000000 C (string)
+lcd Thermometer A
+6.000000 C (string)
+lcd Thermometer B
+6.000000 C (string)
+lcd Thermometer B
+6.000000 C (string)
+lcd Thermometer B
+8.000000 C (string)
+lcd Thermometer A
+8.000000 C (string)
+lcd Failure on Thermometer A (string)
+```
+
+Those three repetitions are normal: only the last one is worth. This
+happens because of how `string/concatenate` node type works: it'll
+output a new string for each step of concatenation.
+If using a real LCD display, this fact should be unnoticed.

--- a/factory-monitor/CMakeLists.txt
+++ b/factory-monitor/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(soletta-demos)
+
+add_definitions(-DSOL_FLOW_NODE_TYPE_MODULE_EXTERNAL)
+
+set(NODE_TYPES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/node_types)
+set(MONITOR_RESOURCE ${NODE_TYPES_DIR}/oic.r.monitor.json)
+set(MODULES_DIR ${CMAKE_BINARY_DIR}/module_descriptions)
+set(STAGE_DIR ${CMAKE_BINARY_DIR}/stage)
+set(STAGE_DIR ${CMAKE_BINARY_DIR}/stage)
+set(MONITOR_GEN_H ${STAGE_DIR}/monitor-gen.h)
+set(MONITOR_GEN_C ${STAGE_DIR}/monitor-gen.c)
+set(MONITOR_JSON ${STAGE_DIR}/monitor.json)
+set(MONITOR_C ${STAGE_DIR}/monitor.c)
+set(MONITOR_GEN_JSON ${MODULES_DIR}/monitor.json)
+set(CUSTOM_NODE_JSON ${NODE_TYPES_DIR}/custom-node.json)
+set(CUSTOM_NODE_C ${NODE_TYPES_DIR}/custom-node.c)
+set(CUSTOM_NODE_GEN_H ${STAGE_DIR}/custom-node-gen.h)
+set(CUSTOM_NODE_GEN_C ${STAGE_DIR}/custom-node-gen.c)
+set(CUSTOM_NODE_GEN_JSON ${STAGE_DIR}/custom-node-gen.json)
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=modulesdir soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SOLETTA_LIB_PREFIX
+    )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=nodeschemapath soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SCHEMA_PATH
+    )
+
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir soletta
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE SOLETTA_DATA_DIR
+    )
+
+add_custom_command(OUTPUT ${MONITOR_C} ${MONITOR_GEN_C} ${MONITOR_GEN_H} ${MONITOR_JSON}
+    DEPENDS ${MONITOR_RESOURCE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${STAGE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULES_DIR}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-oic-gen.py --schema-dir=${NODE_TYPES_DIR} --node-type-json=${MONITOR_JSON} --node-type-impl=${MONITOR_C} --node-type-gen-c=${MONITOR_GEN_C} --node-type-gen-h=${MONITOR_GEN_H}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-validate.py ${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${MONITOR_JSON}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-gen.py --prefix=sol-flow-node-type --genspec-schema=${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${MONITOR_JSON} ${MONITOR_GEN_H} ${MONITOR_GEN_C} ${MONITOR_GEN_JSON}
+    )
+
+add_custom_target(custom-node-gen
+    BYPRODUCTS ${CUSTOM_NODE_GEN_C} ${CUSTOM_NODE_GEN_H} ${CUSTOM_NODE_GEN_JSON}
+    DEPENDS ${CUSTOM_NODE_JSON} ${CUSTOM_NODE_C} ${MONITOR_GEN_H}
+    COMMAND echo "Generating custom node code..."
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${STAGE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULES_DIR}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-validate.py ${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${CUSTOM_NODE_JSON}
+    COMMAND ${CMAKE_FIND_ROOT_PATH}/${SOLETTA_PREFIX}/bin/sol-flow-node-type-gen.py --prefix=sol-flow-node-type --genspec-schema=${CMAKE_FIND_ROOT_PATH}/${SCHEMA_PATH} ${CUSTOM_NODE_JSON} ${CUSTOM_NODE_GEN_H} ${CUSTOM_NODE_GEN_C} ${CUSTOM_NODE_GEN_JSON}
+    COMMAND echo "Done."
+    )
+
+set(BUILT_SOURCES
+    ${MONITOR_GEN_H}
+    ${MONITOR_GEN_C}
+    ${MONITOR_C}
+    ${CUSTOM_NODE_GEN_H}
+    ${CUSTOM_NODE_GEN_C}
+    )
+SET_SOURCE_FILES_PROPERTIES(${BUILT_SOURCES} PROPERTIES
+    GENERATED true
+    )
+
+include_directories(
+    ${SOLETTA_INCLUDE_DIRS}
+    ${STAGE_DIR} #Check if ok
+    )
+
+link_directories(
+    ${SOLETTA_LIBRARY_DIRS}
+    )
+
+add_library(monitor SHARED
+    ${MONITOR_C}
+    )
+set_target_properties(monitor
+    PROPERTIES PREFIX ""
+    )
+target_link_libraries(monitor
+    ${SOLETTA_LIBRARIES}
+    )
+
+add_library(custom-node SHARED
+    ${CUSTOM_NODE_C}
+    )
+add_dependencies(custom-node
+    custom-node-gen
+    )
+set_target_properties(custom-node
+    PROPERTIES PREFIX ""
+    )
+target_link_libraries(custom-node
+    ${SOLETTA_LIBRARIES}
+    )
+
+install(TARGETS monitor custom-node
+    LIBRARY DESTINATION ${SOLETTA_LIB_PREFIX}/flow/
+    )
+
+install(FILES ${MONITOR_GEN_JSON} ${CUSTOM_NODE_GEN_JSON}
+    DESTINATION ${SOLETTA_DATA_DIR}/flow/descriptions
+    )

--- a/factory-monitor/fbp/main.fbp
+++ b/factory-monitor/fbp/main.fbp
@@ -1,0 +1,161 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2016 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is the main flow of the factory-monitor.
+# It has an OIC server - more details about it on server fbp file. Uncomment
+# the one to be used - search for 'Server nodes' on this file.
+# Its OIC client custom-node observers a list of servers, showing
+# temperature readings of them in a rouding roibin fashion. When
+# one of the servers outputs 'FAILURE' alert, client shows corresponding
+# message. Then, one is expected to use Buttons to decide what to do
+# regarding the failure: Dismiss it or report it.
+# To dismiss, one just needs to press btn1. If press btn2, a selector form
+# will be shown to choose a name to report the failure. In the form, btn1
+# chooses a name, and btn2 circle the list of names.
+
+##Server nodes
+#Uncomment the one to be used. For testing purposes on desktop,
+#'server-dummy' shall be enough. If using a real board, one can also
+#uncomment the 'Buzzer' related nodes - search for 'buzzer' on this file.
+DECLARE=Server:fbp:server-dummy.fbp
+#DECLARE=Server:fbp:server-quark-se-devboard.fbp
+
+# Server declaration. With this, sample will run a server and a client
+# on the same Soletta application. However, 'server-dummy.fbp' may be run
+# separately, so you have another servers available. Of course, if you
+# comment following line, you'll have this code only doing 'client' role.
+# Note that to run different servers, you'll need them to be on different
+# machines or virtual machines, as currently, on Linux, clients will only
+# bind to one server. Do not forget to change, on 'server-dummy.fbp',
+# server name, or they'll all look the same.
+# See README.md for more information.
+server(Server)
+
+##Client nodes
+
+scanner(monitor/client-temperature)
+temperature_pool(custom-node/server-pool)
+timer_scan(timer:interval=5000)
+timer_display(timer:interval=3000)
+
+lcd(Display)
+led(Led)
+#buzzer(Buzzer)
+
+raw_btn1(Btn1)
+raw_btn2(Btn2)
+
+btn1(switcher/empty)
+raw_btn1 OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> IN[0] btn1
+
+btn2(switcher/empty)
+raw_btn2 OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> IN[0] btn2
+
+normal_msg(string/concatenate)
+_(constant/string:value="\n") OUT -> IN[1] normal_msg
+_(constant/string:value=" C") OUT -> IN[3] normal_msg
+
+error_msg(string/concatenate)
+_(constant/string:value="Failure on ") OUT -> IN[0] error_msg
+
+supervisor_selector(form/selector:rows=2,columns=16,circular=true)
+supervisors(test/string-generator:sequence="Denethor Saruman Sauron Morgoth --Cancel")
+supervisors OUT -> ADD_ITEM supervisor_selector
+
+msg_switcher(switcher/string:keep_state=true)
+normal_msg OUT -> IN[0] msg_switcher
+error_msg OUT -> IN[1] msg_switcher
+supervisor_selector STRING -> IN[2] msg_switcher
+
+#Start with led OFF and 'Scanning...' message
+_(constant/boolean:value=false) OUT -> IN led
+_(constant/string:value="Scanning...") OUT -> IN lcd
+
+#Continuously scan devices
+timer_scan OUT -> SCAN scanner
+scanner DEVICE_ID -> ADD_DEVICE_ID temperature_pool
+
+#Keep cicling information of known devices
+timer_display OUT -> TICK temperature_pool
+
+#Prepare normal information
+temperature_pool OUT_NAME -> IN[0] normal_msg
+temperature_pool OUT_TEMPERATURE -> IN _(converter/float-to-string) OUT -> IN[2] normal_msg
+
+#Prepare error information
+temperature_pool OUT_NAME -> IN[1] error_msg
+
+#Decides if shows a normal message or an error one
+temperature_pool OUT_FAILURE -> IN failure(boolean/filter)
+failure TRUE -> IN error_screen(converter/empty-to-int:output_value=1) OUT -> IN_PORT msg_switcher
+failure FALSE -> IN normal_screen(converter/empty-to-int:output_value=0) OUT -> IN_PORT msg_switcher
+msg_switcher OUT[0] -> IN lcd
+
+#Turn Led on on failure, stops timer_display and start buzzer
+#If not on failure, do the opposite.
+temperature_pool OUT_FAILURE -> IN led
+temperature_pool OUT_FAILURE -> IN _(boolean/not) OUT -> ENABLED timer_display
+#temperature_pool OUT_FAILURE -> ENABLED buzzer
+
+#Buttons have three states: 0 - Disabled, 1 - On error screen, 2 - On selector screen
+#On failure, enable state 1
+failure TRUE -> IN btn_state1(converter/empty-to-int:output_value=1)
+btn_state1 OUT -> OUT_PORT btn1
+btn_state1 OUT -> OUT_PORT btn2
+
+#If choose 'To report supervisors', enable state 2
+btn2 OUT[1] -> IN btn_state2(converter/empty-to-int:output_value=2)
+btn_state2 OUT -> OUT_PORT btn1
+btn_state2 OUT -> OUT_PORT btn2
+
+#Btn1 act as 'dismiss' on state 1
+btn1 OUT[1] -> IN dismiss(converter/empty-to-boolean:output_value=true)
+dismiss OUT -> IN _(boolean/not) OUT -> SET_FAILURE temperature_pool
+dismiss OUT -> IN _(converter/empty-to-string:output_value="Dismissed") OUT -> IN lcd
+failure FALSE -> IN btn_state0(converter/empty-to-int:output_value=0)
+btn_state0 OUT -> OUT_PORT btn1
+btn_state0 OUT -> OUT_PORT btn2
+
+#Btn2 activated, show a list of 'supervisors'
+btn2 OUT[1] -> IN supervisors_screen(converter/empty-to-int:output_value=2) OUT -> IN_PORT msg_switcher
+
+#Buttons now control form/selector
+btn1 OUT[2] -> SELECT supervisor_selector
+btn2 OUT[2] -> NEXT supervisor_selector
+
+#If '--Cancel' was the chosen item, go back to state 2 (error screen)
+supervisor_selector SELECTED -> IN str_sw(string/starts-with:prefix="--")
+str_sw OUT -> IN canceled(boolean/filter)
+canceled TRUE -> IN btn_state1
+canceled TRUE -> IN error_screen
+
+#If a name was chosen, dismiss error msg
+canceled FALSE -> IN dismiss

--- a/factory-monitor/fbp/server-dummy.fbp
+++ b/factory-monitor/fbp/server-dummy.fbp
@@ -1,0 +1,46 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2016 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is a dummy server - it does not read a temperature sensor,
+# instead, uses a timer and an accumulator to output dummy temperature values.
+
+server_accumulator(int/accumulator)
+server_timer(timer:interval=10000)
+server_temperature(monitor/server-temperature)
+server_name(constant/string:value="Thermometer")
+btn_failure(BtnFailure)
+
+server_name OUT -> IN_NAME server_temperature
+
+server_timer OUT -> INC server_accumulator
+server_accumulator OUT -> IN _(converter/int-to-float) OUT -> IN_TEMPERATURE server_temperature
+
+btn_failure OUT -> IN _(boolean/filter) TRUE -> IN_FAILURE server_temperature

--- a/factory-monitor/fbp/server-quark-se-devboard.fbp
+++ b/factory-monitor/fbp/server-quark-se-devboard.fbp
@@ -1,0 +1,50 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2016 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is the dummy server for the quark-se-devboard. It reads its
+# temperature sensor each 10 seconds, and update OIC monitor server with
+# new readings.
+# It also sets FAILURE state after pressing 'btn_failure' button. Note that
+# button only sets FAILURE state to true - one needs to use monitor client
+# terminals to dismiss the FAILURE state.
+
+temperature_sensor(TemperatureSensor)
+server_timer(timer:interval=10000)
+server_temperature(monitor/server-temperature)
+server_name(constant/string:value="Thermometer")
+btn_failure(BtnFailure)
+
+server_name OUT -> IN_NAME server_temperature
+
+server_timer OUT -> TICK temperature_sensor
+temperature_sensor KELVIN -> KELVIN _(temperature/converter) CELSIUS -> IN_TEMPERATURE server_temperature
+
+btn_failure OUT -> IN _(boolean/filter) TRUE -> IN_FAILURE server_temperature

--- a/factory-monitor/fbp/sol-flow-intel-minnow-max-linux_gt_3_17.json
+++ b/factory-monitor/fbp/sol-flow-intel-minnow-max-linux_gt_3_17.json
@@ -1,0 +1,57 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "Display",
+   "options": {
+    "bus": 0
+   },
+   "type": "console"
+  },
+  {
+   "name": "Led",
+   "options":
+   {
+    "pin": "472",
+    "raw": true
+   },
+   "type": "gpio/writer"
+  },
+  {
+   "name": "Btn1",
+   "options":
+   {
+    "active_low": true,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "473",
+    "raw": true
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "Btn2",
+   "options":
+   {
+    "active_low": true,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "475 ",
+    "raw": true
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "BtnFailure",
+   "options":
+   {
+    "active_low": true,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "474",
+    "raw": true
+   },
+   "type": "gpio/reader"
+  }
+ ]
+}

--- a/factory-monitor/fbp/sol-flow-quark-se-devboard.json
+++ b/factory-monitor/fbp/sol-flow-quark-se-devboard.json
@@ -1,0 +1,72 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "Display",
+   "options": {
+    "bus": 0
+   },
+   "type": "grove/lcd-string"
+  },
+  {
+   "name": "Led",
+   "options":
+   {
+    "active_low": false,
+    "pin": "25"
+   },
+   "type": "gpio/writer"
+  },
+  {
+   "name": "Btn1",
+   "options":
+   {
+    "active_low": false,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "15"
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "Btn2",
+   "options":
+   {
+    "active_low": false,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "17"
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "BtnFailure",
+   "options":
+   {
+    "active_low": false,
+    "edge_falling": true,
+    "edge_rising": true,
+    "pin": "19"
+   },
+   "type": "gpio/reader"
+  },
+  {
+   "name": "Buzzer",
+   "options":
+   {
+    "raw": true,
+    "pin": "0 0",
+    "tune": "ccggaa|111122|300"
+   },
+   "type": "piezo-speaker/sound"
+  },
+  {
+   "name": "TemperatureSensor",
+   "options":
+   {
+    "i2c_bus": 0
+   },
+   "type": "stts751/temperature"
+  }
+ ]
+}

--- a/factory-monitor/fbp/sol-flow.json
+++ b/factory-monitor/fbp/sol-flow.json
@@ -1,0 +1,28 @@
+{
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
+ "nodetypes": [
+  {
+   "name": "Display",
+   "type": "gtk/label"
+  },
+  {
+   "name": "Led",
+   "options": {
+    "rgb": "0|255|0"
+   },
+   "type": "gtk/led"
+  },
+  {
+   "name": "Btn1",
+   "type": "gtk/pushbutton"
+  },
+  {
+   "name": "Btn2",
+   "type": "gtk/pushbutton"
+  },
+  {
+   "name": "BtnFailure",
+   "type": "gtk/pushbutton"
+  }
+ ]
+}

--- a/factory-monitor/node_types/custom-node.c
+++ b/factory-monitor/node_types/custom-node.c
@@ -1,0 +1,374 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "custom-node-gen.h"
+#include "monitor-gen.h"
+#include "sol-flow-static.h"
+
+#include <sol-mainloop.h>
+#include <errno.h>
+
+struct resource_data {
+    char *device_id;
+    char *name;
+    double temperature;
+    bool failure;
+    bool reset_failure;
+    union {
+        struct {
+            uint8_t temperature_ready : 1;
+            uint8_t name_ready : 1;
+            uint8_t failure_ready : 1;
+        };
+        uint8_t ready;
+    };
+};
+
+struct internal_data {
+    struct sol_vector resources;
+    struct sol_timeout *timeout;
+    struct sol_flow_node *node;
+    uint16_t current_idx;
+    uint16_t fetch_idx;
+};
+
+static int
+next_idx(int idx, int max_idx)
+{
+    if (++idx >= max_idx)
+        idx = 0;
+
+    return idx;
+}
+
+static bool
+timeout_cb(void *data)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+
+    if (mdata->resources.len == 0) {
+        SOL_DBG("No resources available yet");
+        return true;
+    }
+
+    mdata->fetch_idx = next_idx(mdata->fetch_idx, mdata->resources.len);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, true);
+
+    sol_flow_send_string_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_DEVICE_ID,
+        resource->device_id);
+
+    return true;
+}
+
+static int
+internal_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct internal_data *mdata = data;
+
+    sol_vector_init(&mdata->resources, sizeof(struct resource_data));
+
+    mdata->timeout = sol_timeout_add(900, timeout_cb, mdata);
+    SOL_NULL_CHECK(mdata->timeout, -ENOMEM);
+
+    mdata->node = node;
+
+    return 0;
+}
+
+static void
+internal_close(struct sol_flow_node *node, void *data)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    uint16_t i;
+
+    SOL_VECTOR_FOREACH_IDX (&mdata->resources, resource, i) {
+        free(resource->name);
+        free(resource->device_id);
+    }
+    sol_vector_clear(&mdata->resources);
+
+    sol_timeout_del(mdata->timeout);
+}
+
+static int
+internal_process_failure(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    bool in_value;
+    int r;
+
+    r = sol_flow_packet_get_boolean(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOMEM);
+
+    /* If previously on failure state and not anymore, we send packet
+     * even without tick, because timer was stopped */
+    if (resource->failure && !in_value) {
+        sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_FAILURE,
+            in_value);
+    }
+    if (resource->reset_failure) {
+        sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_FAILURE,
+            false);
+        resource->reset_failure = false;
+    }
+    resource->failure = in_value;
+    resource->failure_ready = true;
+
+    return 0;
+}
+
+static int
+internal_process_name(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    const char *in_value;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    if (!resource->name || strcmp(resource->name, in_value)) {
+        free(resource->name);
+        resource->name = strdup(in_value);
+        resource->name_ready = true;
+    }
+
+    return 0;
+}
+
+static int
+internal_process_temperature(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    struct sol_drange in_value;
+    int r;
+
+    r = sol_flow_packet_get_drange(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->fetch_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    resource->temperature = in_value.val;
+    resource->name_ready = true;
+
+    return 0;
+}
+
+static int
+process_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    struct resource_data *resource;
+    uint16_t last_idx;
+
+    if (mdata->resources.len == 0) {
+        SOL_WRN("No resource available");
+        return 0;
+    }
+
+    last_idx = mdata->current_idx;
+    mdata->current_idx = next_idx(mdata->current_idx, mdata->resources.len);
+
+    resource = sol_vector_get(&mdata->resources, mdata->current_idx);
+    SOL_NULL_CHECK(resource, -ENOENT);
+
+    /* Let's try to find a ready resource, i.e., one whose data is known
+     * If we fail, give up*/
+    while (!resource->ready) {
+        mdata->current_idx = next_idx(mdata->current_idx, mdata->resources.len);
+        if (mdata->current_idx == last_idx) {
+            SOL_DBG("No ready resource");
+            return 0; /* No ready resource*/
+        }
+
+        resource = sol_vector_get(&mdata->resources, mdata->current_idx);
+        SOL_NULL_CHECK(resource, -ENOENT);
+    }
+
+    sol_flow_send_string_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__DEVICE_ID, resource->device_id);
+    sol_flow_send_string_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_NAME, resource->name);
+    sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_FAILURE, resource->failure);
+    sol_flow_send_drange_value_packet(node,
+        SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_TEMPERATURE,
+        resource->temperature);
+
+    return 0;
+}
+
+static int
+process_failure(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    int r;
+    bool in_value;
+    struct resource_data *resource;
+
+    r = sol_flow_packet_get_boolean(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    resource = sol_vector_get(&mdata->resources, mdata->current_idx);
+    /* Our internal oic monitor node may not be pointing to device that
+     * failed, so we let it do it when it reach its turn.
+     * TODO improve this. Maybe stopping fetch round robin when gets a failure? */
+    resource->reset_failure = true;
+
+    return 0;
+}
+
+static int
+add_device_id_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct internal_data *mdata = data;
+    const char *in_value;
+    struct resource_data *resource;
+    uint16_t i;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    SOL_VECTOR_FOREACH_IDX (&mdata->resources, resource, i) {
+        if (!strcmp(resource->device_id, in_value)) {
+            SOL_DBG("Ignoring known resource %s", in_value);
+            return 0;
+        }
+    }
+
+    resource = sol_vector_append(&mdata->resources);
+    SOL_NULL_CHECK(resource, -ENOMEM);
+
+    resource->device_id = strdup(in_value);
+    SOL_NULL_CHECK_GOTO(resource->device_id, err);
+
+    return 0;
+
+err:
+    sol_vector_del_last(&mdata->resources);
+    return -ENOMEM;
+}
+
+static void
+custom_pool_new_type(const struct sol_flow_node_type **current)
+{
+    struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *oic_client;
+
+    static struct sol_flow_static_node_spec nodes[] = {
+        { NULL, "custom-controller", NULL },
+        { NULL, "monitor-client-temperature", NULL },
+        SOL_FLOW_STATIC_NODE_SPEC_GUARD
+    };
+
+    /**
+     * Remember: SET_FAILURE port will send a message to server about failure;
+     *           OUT_FAILURE port will send locally current status, like
+     *           OUT_TEMPERATURE.
+     */
+    static const struct sol_flow_static_conn_spec conns[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_DEVICE_ID, 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__IN__DEVICE_ID },
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__SET_FAILURE, 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__IN__IN_FAILURE },
+
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_FAILURE, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_FAILURE },
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_TEMPERATURE, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_TEMPERATURE },
+        { 1, SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE__OUT__OUT_NAME, 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__IN_NAME },
+
+        SOL_FLOW_STATIC_CONN_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_port_spec exported_out[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__DEVICE_ID},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_TEMPERATURE},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_NAME},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__OUT__OUT_FAILURE},
+        SOL_FLOW_STATIC_PORT_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_port_spec exported_in[] = {
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__SET_FAILURE},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__TICK},
+        { 0, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER__IN__ADD_DEVICE_ID},
+        SOL_FLOW_STATIC_PORT_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_spec spec = {
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
+        .nodes = nodes,
+        .conns = conns,
+        .exported_in = exported_in,
+        .exported_out = exported_out
+    };
+
+    if (sol_flow_get_node_type("monitor", SOL_FLOW_NODE_TYPE_MONITOR_CLIENT_TEMPERATURE, &oic_client) < 0) {
+        *current = NULL;
+        return;
+    }
+
+    nodes[0].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL_CONTROLLER;
+    nodes[1].type = oic_client;
+
+    type = sol_flow_static_new_type(&spec);
+    SOL_NULL_CHECK(type);
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    type->description = (*current)->description;
+#endif
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
+    *current = type;
+}
+
+static void
+custom_init_type(void)
+{
+    custom_pool_new_type(&SOL_FLOW_NODE_TYPE_CUSTOM_NODE_SERVER_POOL);
+}
+
+#include "custom-node-gen.c"

--- a/factory-monitor/node_types/custom-node.json
+++ b/factory-monitor/node_types/custom-node.json
@@ -1,0 +1,160 @@
+{
+   "$schema": "http://solettaproject.github.io/soletta/schemas/node-type-genspec.schema",
+   "name": "server-pool",
+   "meta": {
+      "author": "Intel Corporation",
+      "license": "BSD-3-Clause",
+      "version": "1"
+   },
+   "types": [
+      {
+         "category": "internal",
+         "description": "Controler for custom node. Shall keep a list of N servers, continuously ask their status, etc",
+         "in_ports": [
+            {
+               "description": "Failure state",
+               "name": "SET_FAILURE",
+               "methods": {
+                  "process": "process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Current sensed Temperature",
+               "name": "IN_TEMPERATURE",
+               "methods": {
+                  "process": "internal_process_temperature"
+               },
+               "data_type": "float"
+            },
+            {
+               "description": "Friendly device name (e.g. Kitchen Temperature)",
+               "name": "IN_NAME",
+               "methods": {
+                  "process": "internal_process_name"
+               },
+               "data_type": "string"
+            },
+            {
+               "description": "Failure state",
+               "name": "IN_FAILURE",
+               "methods": {
+                  "process": "internal_process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Each packet received on this port sends next server information to output ports",
+               "name": "TICK",
+               "methods": {
+                  "process": "process_tick"
+               },
+               "data_type": "any"
+            },
+            {
+               "description": "Add device id to be observed.",
+               "name": "ADD_DEVICE_ID",
+               "methods": {
+                  "process": "add_device_id_process"
+               },
+               "data_type": "string"
+            }
+         ],
+         "methods": {
+            "open": "internal_open",
+            "close": "internal_close"
+         },
+         "name": "custom-node/server-pool-controller",
+         "out_ports": [
+            {
+               "description": "Send DEVICE_ID packet to set client device id",
+               "name": "SET_DEVICE_ID",
+               "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "SET_FAILURE",
+               "data_type": "boolean"
+            },
+            {
+                "description": "Id of current server, from where cames current temperature, etc.",
+                "name": "DEVICE_ID",
+                "data_type": "string"
+            },
+            {
+                "description": "Current sensed Temperature",
+                "name": "OUT_TEMPERATURE",
+                "data_type": "float"
+            },
+            {
+                "description": "Friendly device name (e.g. Kitchen Temperature)",
+                "name": "OUT_NAME",
+                "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "OUT_FAILURE",
+               "data_type": "boolean"
+            }
+         ],
+         "private_data_type": "internal_data"
+      },
+      {
+         "category": "custom",
+         "description": "Custom node. Shall keep a list of N servers, continuously ask their status, etc",
+         "in_ports": [
+            {
+               "description": "Failure state",
+               "name": "SET_FAILURE",
+               "methods": {
+                  "process": "process_failure"
+               },
+               "data_type": "boolean"
+            },
+            {
+               "description": "Each packet received on this port sends next server information to output ports",
+               "name": "TICK",
+               "methods": {
+                  "process": "process_tick"
+               },
+               "data_type": "any"
+            },
+            {
+               "description": "Add device id to be observed.",
+               "name": "ADD_DEVICE_ID",
+               "methods": {
+                  "process": "add_device_id_process"
+               },
+               "data_type": "string"
+            }
+         ],
+         "methods": {
+            "init_type": "custom_init_type"
+         },
+         "name": "custom-node/server-pool",
+         "out_ports": [
+            {
+                "description": "Send packets with IDs for all servers that respond to scan request. Such IDs can be used to connect to a client to a different server through input port DEVICE_ID",
+                "name": "DEVICE_ID",
+                "data_type": "string"
+            },
+            {
+                "description": "Current sensed Temperature",
+                "name": "OUT_TEMPERATURE",
+                "data_type": "float"
+            },
+            {
+                "description": "Friendly device name (e.g. Kitchen Temperature)",
+                "name": "OUT_NAME",
+                "data_type": "string"
+            },
+            {
+               "description": "Send failure packet to current server",
+               "name": "OUT_FAILURE",
+               "data_type": "boolean"
+            }
+         ],
+         "private_data_type": "internal_data"
+      }
+   ]
+}

--- a/factory-monitor/node_types/oic.r.monitor.json
+++ b/factory-monitor/node_types/oic.r.monitor.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Test temperature",
+  "definitions": {
+    "core.temperature": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Friendly device name (e.g. Kitchen Temperature)"
+        },
+        "temperature": {
+          "type": "number",
+          "description": "ReadOnly,Current sensed Temperature"
+        },
+        "failure": {
+          "type": "boolean",
+          "description": "Current failure status"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [ "temperature" ]
+}


### PR DESCRIPTION
v3: Fixes issues pointed by @glima

This demo exemplifies a factory floor monitor: several terminal
that connect, using OIC, to several monitors. Each monitor outputs
current temperature readings and a FAILURE state.
Terminals usually show monitor temperature on a round robin fashion.
However, if any monitor sets its FAILURE state to true, terminals will
stop showing temperature and will show the failure status.
When on failure state, one can use available buttons to 1) Dismiss
failure status 2) Report to some 'supervisor' - action that dismiss
failure status as well. After dimiss, terminals go back to showing
monitors temperature.
One can see this demo on desktop - with fake
temperatures - also, see instructions on README.md.

Signed-off-by: Ederson de Souza ederson.desouza@intel.com
